### PR TITLE
Protocol additions

### DIFF
--- a/doc/source/reference/device.rst
+++ b/doc/source/reference/device.rst
@@ -3,3 +3,10 @@
 
 .. automodule:: jvconnected.device
     :members:
+
+
+.. rubric:: Footnotes
+
+.. [#fsync_master] The documentation for this isn't entirely clear, so the
+    behavior is only assumed (as the author only has one type of camera to
+    test with).

--- a/src/jvconnected/device.py
+++ b/src/jvconnected/device.py
@@ -373,6 +373,8 @@ class NTPParams(ParameterGroup):
     """Whether the device is syncronized to the :attr:`server <address>`"""
 
     sync_master: bool = Property(False)
+    """True if the device is being used as a TC and sync (Genlock) master [#fsync_master]_
+    """
 
     def __init__(self, device: Device, **kwargs):
         super().__init__(device, **kwargs)

--- a/src/jvconnected/ui/models/device.py
+++ b/src/jvconnected/ui/models/device.py
@@ -823,6 +823,46 @@ class SeesawParam(SingleParam):
     """True if the parameter is moving
     """
 
+class MasterBlackPosModel(SeesawParam):
+    """MasterBlack seesaw operation
+    """
+
+    _param_group_key = 'exposure'
+    _param_group_attr = 'master_black'
+
+    @asyncSlot(int)
+    async def up(self, speed: int):
+        """Move MasterBlack up at the specified speed (0 to 8)
+        """
+        await self.move('Up', speed)
+
+    @asyncSlot(int)
+    async def down(self, speed: int):
+        """Move MasterBlack down at the specified speed (0 to 8)
+        """
+        await self.move('Down', speed)
+
+    @asyncSlot()
+    async def stop(self):
+        """Stop moving
+        """
+        await self.move('Stop', 0)
+
+    @logger.catch
+    async def move(self, direction: MasterBlackDirection, speed: int):
+        async with self._request_pending:
+            await self.paramGroup.seesaw_master_black(direction, speed)
+
+    def _on_param_group_set(self, param_group):
+        super()._on_param_group_set(param_group)
+        param_group.bind(master_black_speed=self._on_master_black_speed)
+
+    def _on_master_black_speed(self, instance, value, **kwargs):
+        if instance is not self.paramGroup:
+            return
+        self.currentSpeed = value
+
+
 class FocusPosModel(SeesawParam):
     """Focus position and movement
     """
@@ -1234,7 +1274,7 @@ class TallyModel(ParamBase):
 MODEL_CLASSES = (
     DeviceConfigModel, DeviceModel, NTPParamsModel, CameraParamsModel, IrisModel, BatteryParamsModel,
     GainModeModel, GainValueModel, MasterBlackModel, DetailModel, TallyModel,
-    FocusModeModel, FocusPosModel, ZoomPosModel,
+    MasterBlackPosModel, FocusModeModel, FocusPosModel, ZoomPosModel,
     WbModeModel, WbColorTempModel, WbPaintModelBase, WbRedPaintModel, WbBluePaintModel,
 )
 

--- a/src/jvconnected/ui/models/device.py
+++ b/src/jvconnected/ui/models/device.py
@@ -506,6 +506,8 @@ class CameraParamsModel(ParamBase):
         await self.paramGroup.send_menu_button(enum_value)
 
 class NTPParamsModel(ParamBase):
+    """Qt bridge for :class:`jvconnected.device.NTPParams`
+    """
     _param_group_key = 'ntp'
     _prop_attr_map = {
         'address':'address', 'tc_sync':'tcSync',
@@ -526,21 +528,27 @@ class NTPParamsModel(ParamBase):
     def _g_address(self) -> str: return self._address
     def _s_address(self, value: str): self._generic_setter('_address', value)
     address: str = Property(str, _g_address, _s_address, notify=_n_address)
+    """Alias for :class:`jvconnected.device.NTPParams.address`"""
 
     def _g_tcSync(self) -> bool: return self._tcSync
     def _s_tcSync(self, value: bool): self._generic_setter('_tcSync', value)
     tcSync: bool = Property(bool, _g_tcSync, _s_tcSync, notify=_n_tcSync)
+    """Alias for :class:`jvconnected.device.NTPParams.tc_sync`"""
 
     def _g_syncronized(self) -> bool: return self._syncronized
     def _s_syncronized(self, value: bool): self._generic_setter('_syncronized', value)
     syncronized: bool = Property(bool, _g_syncronized, _s_syncronized, notify=_n_syncronized)
+    """Alias for :class:`jvconnected.device.NTPParams.syncronized`"""
 
     def _g_syncMaster(self) -> bool: return self._syncMaster
     def _s_syncMaster(self, value: bool): self._generic_setter('_syncMaster', value)
     syncMaster: bool = Property(bool, _g_syncMaster, _s_syncMaster, notify=_n_syncMaster)
+    """Alias for :class:`jvconnected.device.NTPParams.sync_master`"""
 
     @asyncSlot(str)
     async def setAddress(self, address: str):
+        """Set the NTP server using :meth:`jvconnected.device.NTPParams.set_address`
+        """
         await self.paramGroup.set_address(address)
 
 class BatteryParamsModel(ParamBase):
@@ -858,6 +866,8 @@ class FocusPosModel(SeesawParam):
 
 
 class ZoomPresetModel(GenericQObject):
+    """Qt bridge for :class:`jvconnected.device.ZoomPreset`
+    """
     _n_name = Signal()
     _n_value = Signal()
     _n_isActive = Signal()
@@ -961,6 +971,8 @@ class ZoomPosModel(SeesawParam):
     async def setPreset(self, name: str):
         """Store the current zoom :attr:`pos` to a preset
 
+        (See :meth:`jvconnected.device.PresetZoomParams.set_preset`)
+
         Arguments:
             name: The preset name (one of ``["A", "B", "C"]``)
         """
@@ -972,6 +984,8 @@ class ZoomPosModel(SeesawParam):
     @asyncSlot(str)
     async def recallPreset(self, name: str):
         """Recall the zoom preset matching the given :attr:`~ZoomPresetModel.name`
+
+        (See :meth:`jvconnected.device.PresetZoomParams.recall_preset`)
         """
         device = self.paramGroup.device
         pg = device.preset_zoom
@@ -979,7 +993,10 @@ class ZoomPosModel(SeesawParam):
 
     @asyncSlot(str)
     async def clearPreset(self, name: str):
-        """Clear the stored value of the preset by the given :attr:`~ZoomPresetModel.name`
+        """Clear the stored value of the preset by the given
+        :attr:`~ZoomPresetModel.name`
+
+        (See :meth:`jvconnected.device.PresetZoomParams.clear_preset`)
         """
         device = self.paramGroup.device
         pg = device.preset_zoom

--- a/src/jvconnected/ui/qml/Camera.qml
+++ b/src/jvconnected/ui/qml/Camera.qml
@@ -21,6 +21,11 @@ Control {
         deviceIndexUpdate();
     }
 
+    function showOptionsDialog(){
+        optionsDialog.reset();
+        optionsDialog.open();
+    }
+
     // Layout.leftMargin: 4
     // Layout.rightMargin: 4
     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
@@ -43,11 +48,23 @@ Control {
         content: ColumnLayout {
 
             ColumnLayout {
-                ValueLabel {
-                    labelText: 'Index'
-                    valueText: root.device.deviceIndex
-                    orientation: Qt.Horizontal
-                    Layout.fillWidth: true
+                RowLayout {
+                    ValueLabel {
+                        labelText: 'Index'
+                        valueText: root.device.deviceIndex
+                        orientation: Qt.Horizontal
+                    }
+                    Item { Layout.fillWidth: true }
+                    ValueLabel {
+                        labelText: 'Name'
+                        valueText: root.device.displayName
+                        orientation: Qt.Horizontal
+                    }
+                    Item { Layout.fillWidth: true }
+                    IconButton {
+                        iconName: 'faCog'
+                        onClicked: { root.showOptionsDialog() }
+                    }
                 }
                 BatteryControls { model: root.model }
             }
@@ -267,6 +284,44 @@ Control {
             y: parent.y + root.topPadding
             width: root.availableWidth
             height: root.availableHeight
+        }
+    }
+
+    Component {
+        id: optionsDialogComponent
+        CameraOptionsDialog {
+            deviceModel: root.model
+            width: 600
+            height: 400
+            modal: true
+            focus: true
+            parent: Overlay.overlay
+            x: Math.round((parent.width - width) / 2)
+            y: Math.round((parent.height - height) / 2)
+        }
+    }
+
+    Loader {
+        id: optionsDialog
+
+        function open(){
+            var status = optionsDialog.status;
+            if (status == Loader.Null){
+                optionsDialog.sourceComponent = optionsDialogComponent;
+            } else if (status == Loader.Ready){
+                optionsDialog.item.open();
+            }
+        }
+
+        function reset(){
+            if (optionsDialog.status == Loader.Ready){
+                optionsDialog.item.reset();
+            }
+        }
+
+        onLoaded: {
+            optionsDialog.item.reset();
+            optionsDialog.item.open();
         }
     }
 }

--- a/src/jvconnected/ui/qml/Camera.qml
+++ b/src/jvconnected/ui/qml/Camera.qml
@@ -16,6 +16,7 @@ Control {
     property alias deviceIndex: model.deviceIndex
     property CameraModel model: model
     signal deviceIndexUpdate()
+    // NOTE: width should be 390
 
     onDeviceIndexChanged: {
         deviceIndexUpdate();
@@ -44,11 +45,15 @@ Control {
         headerBackgroundColor: '#215c98'
         headerTextColor: '#ffffff'
         horizontalPadding: 8
+        implicitWidth: 376
 
         content: ColumnLayout {
+            // NOTE: width should be 376
 
             ColumnLayout {
+                // NOTE: width should be 360
                 RowLayout {
+                    // NOTE: width should be 342
                     ValueLabel {
                         labelText: 'Index'
                         valueText: root.device.deviceIndex
@@ -196,18 +201,18 @@ Control {
                     }
                     RowLayout {
                         MyGroupBox {
-                            title: 'Gain'
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-
-                            content: GainControls { model: root.model }
-                        }
-                        MyGroupBox {
                             title: 'Master Black'
                             Layout.fillWidth: true
                             Layout.fillHeight: true
 
                             content: MasterBlackControls { model: root.model }
+                        }
+                        MyGroupBox {
+                            title: 'Gain'
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+
+                            content: GainControls { model: root.model }
                         }
                     }
                 }

--- a/src/jvconnected/ui/qml/CameraModel.qml
+++ b/src/jvconnected/ui/qml/CameraModel.qml
@@ -16,6 +16,7 @@ QtObject {
     }
 
     property CameraParamsModel cameraParams: CameraParamsModel { device: root.device }
+    property NTPParamsModel ntpParams: NTPParamsModel { device: root.device }
     property BatteryParamsModel battery: BatteryParamsModel { device: root.device }
     property IrisModel iris: IrisModel { device: root.device }
     property GainModeModel gainMode: GainModeModel { device: root.device }

--- a/src/jvconnected/ui/qml/CameraModel.qml
+++ b/src/jvconnected/ui/qml/CameraModel.qml
@@ -22,6 +22,7 @@ QtObject {
     property GainModeModel gainMode: GainModeModel { device: root.device }
     property GainValueModel gainValue: GainValueModel { device: root.device }
     property MasterBlackModel masterBlack: MasterBlackModel { device: root.device }
+    property MasterBlackPosModel masterBlackPos: MasterBlackPosModel { device: root.device }
     property FocusModeModel focusMode: FocusModeModel { device: root.device }
     property FocusPosModel focusPos: FocusPosModel { device: root.device }
     property ZoomPosModel zoomPos: ZoomPosModel { device: root.device }

--- a/src/jvconnected/ui/qml/CameraOptionsDialog.qml
+++ b/src/jvconnected/ui/qml/CameraOptionsDialog.qml
@@ -1,0 +1,73 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
+import Qt.labs.settings 1.0
+import DeviceModels 1.0
+import Controls 1.0
+
+Dialog {
+    id: root
+    title: (cameraIndex == -1) ? 'Camera Options' : 'Camera ' + cameraIndex.toString() + ' Options'
+    standardButtons: Dialog.Ok | Dialog.Cancel | Dialog.Apply | Dialog.Reset
+
+    property CameraModel deviceModel
+    property int cameraIndex: deviceModel ? deviceModel.device.deviceIndex : -1
+
+    MyTabBar {
+        id: bar
+        width: parent.width
+
+        // MyTabButton { text: 'General'; width: bar.maxItemWidth }
+        MyTabButton { text: 'NTP'; width: bar.maxItemWidth }
+        // MyTabButton { text: 'Network'; width: bar.maxItemWidth }
+    }
+
+    StackLayout {
+        id: stack
+        currentIndex: bar.currentIndex
+        anchors.top: bar.bottom
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: 8
+
+        // Control {
+        //     id: generalSettings
+        //     deviceModel: root.deviceModel
+
+        //     Connections {
+        //         target: root
+        //         function onAccepted() { generalSettings.submit() }
+        //         function onApplied() { generalSettings.submit() }
+        //         function onRejected() { generalSettings.cancel() }
+        //         function onReset() { generalSettings.cancel() }
+        //     }
+        // }
+
+        NTPOptions {
+            id: ntpSettings
+            deviceModel: root.deviceModel
+
+            Connections {
+                target: root
+                function onAccepted() { ntpSettings.submit() }
+                function onApplied() { ntpSettings.submit() }
+                function onRejected() { ntpSettings.cancel() }
+                function onReset() { ntpSettings.cancel() }
+            }
+        }
+
+        // Control {
+        //     id: networkSettings
+        //     deviceModel: root.deviceModel
+
+        //     Connections {
+        //         target: root
+        //         function onAccepted() { networkSettings.submit() }
+        //         function onApplied() { networkSettings.submit() }
+        //         function onRejected() { networkSettings.cancel() }
+        //         function onReset() { networkSettings.cancel() }
+        //     }
+        // }
+    }
+}

--- a/src/jvconnected/ui/qml/ControlGroups/GainControls.qml
+++ b/src/jvconnected/ui/qml/ControlGroups/GainControls.qml
@@ -11,21 +11,24 @@ ColumnLayout {
     ValueLabel {
         labelText: 'Mode'
         valueText: root.model ? root.model.gainMode.value : ''
+        Layout.fillWidth: true
+    }
+
+    ValueLabel {
+        labelText: 'Value'
+        valueText: root.model ? model.gainValue.value : ''
+        valueFont.pointSize: 12
+        valueFont.bold: true
+        Layout.fillWidth: true
     }
 
     RowLayout {
-
-        ValueLabel {
-            labelText: 'Value'
-            valueText: root.model ? model.gainValue.value : ''
-            valueFont.pointSize: 12
-            valueFont.bold: true
-        }
-
-
+        Item { Layout.fillWidth: true }
         PlusMinusButtons {
+            Layout.alignment: Qt.AlignVCenter || Qt.AlignHCenter
             onPlusClicked: model.gainValue.increase()
             onMinusClicked: model.gainValue.decrease()
         }
+        Item { Layout.fillWidth: true }
     }
 }

--- a/src/jvconnected/ui/qml/ControlGroups/MasterBlackControls.qml
+++ b/src/jvconnected/ui/qml/ControlGroups/MasterBlackControls.qml
@@ -1,24 +1,66 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
+import DeviceModels 1.0
 import Controls 1.0
 
-RowLayout {
+ColumnLayout {
     id: root
 
     property CameraModel model
+    property MasterBlackPosModel mbPos: model ? model.masterBlackPos : null
 
-    ValueLabel {
-        labelText: 'Value'
-        valueText: root.model ? model.masterBlack.value : ''
-        valueFont.pointSize: 12
-        valueFont.bold: true
+    RowLayout {
+        ValueLabel {
+            labelText: 'Value'
+            valueText: root.model ? model.masterBlack.value : ''
+            valueFont.pointSize: 12
+            valueFont.bold: true
+        }
+
+        Item { Layout.fillWidth: true }
+
+        PlusMinusButtons {
+            onPlusClicked: root.model.masterBlack.increase()
+            onMinusClicked: root.model.masterBlack.decrease()
+        }
     }
 
-    Item { Layout.fillWidth: true }
+    ShuttleSlider {
+        id: mbSlider
+        orientation: Qt.Horizontal
+        from: -8
+        to: 8
+        stepSize: 1
+        verticalPadding: 10
+        snapMode: Slider.SnapAlways
+        property bool captured: false
+        Layout.fillWidth: true
 
-    PlusMinusButtons {
-        onPlusClicked: root.model.masterBlack.increase()
-        onMinusClicked: root.model.masterBlack.decrease()
+        onPressedChanged: {
+            captured = pressed;
+            if (!pressed){
+                root.mbPos.stop();
+            }
+        }
+
+        Connections {
+            target: root.mbPos
+            function onCurrentSpeedChanged(){
+                if (!mbSlider.captured){
+                    mbSlider.value = Qt.binding(function(){ return root.mbPos.currentSpeed; });
+                }
+            }
+        }
+
+        onValueChanged: {
+            if (captured && pressed){
+                if (value < 0){
+                    root.mbPos.down(-value);
+                } else {
+                    root.mbPos.up(value);
+                }
+            }
+        }
     }
 }

--- a/src/jvconnected/ui/qml/ControlGroups/ZoomControls.qml
+++ b/src/jvconnected/ui/qml/ControlGroups/ZoomControls.qml
@@ -15,6 +15,7 @@ ColumnLayout {
             ShuttleSlider {
                 id: speedSlider
                 orientation: Qt.Horizontal
+                Layout.fillWidth: true
                 from: -8
                 to: 8
                 stepSize: 1
@@ -52,6 +53,7 @@ ColumnLayout {
                 from: 0
                 to: 499
                 value: root.zoomPos ? root.zoomPos.pos : 0
+                Layout.fillWidth: true
             }
         }
         Item { Layout.fillWidth: true }

--- a/src/jvconnected/ui/qml/ControlGroups/ZoomControls.qml
+++ b/src/jvconnected/ui/qml/ControlGroups/ZoomControls.qml
@@ -62,4 +62,55 @@ ColumnLayout {
             color: 'white'
         }
     }
+
+    RowLayout {
+        Label {
+            text: 'Presets'
+        }
+        ColumnLayout {
+            id: presetModeBtns
+            property bool recordEnabled: false
+            IconButton {
+                iconName: 'faSave'
+                checkable: true
+                checked: parent.recordEnabled
+                font.pointSize: 9
+                Layout.maximumHeight: 16
+                padding: 0
+                width: height
+                backgroundBlendColor: checked ? Qt.rgba(.8,0,0,1) : Qt.rgba(.2,0,0,.8)
+                onClicked: { parent.recordEnabled = !parent.recordEnabled }
+            }
+            IconButton {
+                iconName: 'faPlayCircle'
+                checkable: true
+                checked: !parent.recordEnabled
+                font.pointSize: 9
+                Layout.maximumHeight: 16
+                padding: 0
+                width: height
+                backgroundBlendColor: checked ? Qt.rgba(0,.8,0,1) : Qt.rgba(0,.2,0,.8)
+                onClicked: { parent.recordEnabled = !parent.recordEnabled }
+
+            }
+        }
+        RowLayout {
+            Repeater {
+                model: root.zoomPos ? root.zoomPos.presets : []
+                RoundButton {
+                    text: modelData.name
+                    highlighted: modelData.isActive
+
+                    onClicked: {
+                        if (presetModeBtns.recordEnabled){
+                            root.zoomPos.setPreset(modelData.name);
+                            presetModeBtns.recordEnabled = false;
+                        } else {
+                            root.zoomPos.recallPreset(modelData.name);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/jvconnected/ui/qml/Controls/IconButton.qml
+++ b/src/jvconnected/ui/qml/Controls/IconButton.qml
@@ -1,5 +1,7 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.impl 2.12
+import QtQuick.Templates 2.12 as T
 import Fonts 1.0
 
 RoundButton {
@@ -9,6 +11,8 @@ RoundButton {
     radius: round ? width : 0
     property alias iconName: iconFont.iconName
     property alias pointSize: iconFont.pointSize
+    property alias backgroundBlendColor: background.blendColor
+    property alias textBlendColor: contentItem.blendColor
 
     IconFont {
         id: iconFont
@@ -16,4 +20,34 @@ RoundButton {
 
     text: iconFont.text
     font: iconFont.iconFont
+
+    contentItem: IconLabel {
+        id: contentItem
+        spacing: control.spacing
+        mirrored: control.mirrored
+        display: control.display
+        property color defaultColor: control.checked || control.highlighted ? control.palette.brightText :
+               control.flat && !control.down ? (control.visualFocus ? control.palette.highlight : control.palette.windowText) : control.palette.buttonText
+        property color blendColor: '#00000000'
+        color: Qt.tint(defaultColor, blendColor)
+
+        icon: control.icon
+        text: control.text
+        font: control.font
+    }
+
+    background: Rectangle {
+        id: background
+        implicitWidth: 40
+        implicitHeight: 40
+        radius: control.radius
+        opacity: enabled ? 1 : 0.3
+        visible: !control.flat || control.down || control.checked || control.highlighted
+        property color defaultColor: Color.blend(control.checked || control.highlighted ? control.palette.dark : control.palette.button,
+                                                                    control.palette.mid, control.down ? 0.5 : 0.0)
+        property color blendColor: '#00000000'
+        color: Qt.tint(defaultColor, blendColor)
+        border.color: control.palette.highlight
+        border.width: control.visualFocus ? 2 : 0
+    }
 }

--- a/src/jvconnected/ui/qml/Controls/TextInput.qml
+++ b/src/jvconnected/ui/qml/Controls/TextInput.qml
@@ -14,6 +14,7 @@ Control {
     font.pointSize: 9
 
     signal submit(string value)
+    signal textEdited(string value)
 
     contentItem: GridLayout {
         id: grid
@@ -46,6 +47,9 @@ Control {
             Layout.fillHeight: root.orientation == Qt.Horizontal ? true : false
             onEditingFinished: {
                 root.submit(text);
+            }
+            onTextEdited: {
+                root.textEdited(text);
             }
         }
     }

--- a/src/jvconnected/ui/qml/NTPOptions.qml
+++ b/src/jvconnected/ui/qml/NTPOptions.qml
@@ -1,0 +1,110 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
+import DeviceModels 1.0
+import Controls 1.0
+
+Control {
+    id: root
+
+    property string address
+    property bool hasChanges: false
+    property var changedProps: []
+    property CameraModel deviceModel
+    property NTPParamsModel paramsModel: deviceModel.ntpParams
+
+    signal submit()
+    signal cancel()
+
+    horizontalPadding: 20
+    topPadding: 10
+    bottomPadding: 30
+
+    onParamsModelChanged: {
+        if (root.paramsModel) {
+            updateFromModel();
+        }
+    }
+
+    onSubmit: { applyChanges() }
+
+    onCancel: { updateFromModel() }
+
+    function updateFromModel(){
+        address = root.paramsModel.address;
+        hasChanges = false;
+        changedProps = [];
+    }
+
+    function applyChanges(){
+        if (hasChanges) {
+            for (const prop of changedProps){
+                if (prop == 'address'){
+                    root.paramsModel.setAddress(root.address);
+                }
+            }
+        }
+        hasChanges = false;
+        changedProps = [];
+    }
+
+    Connections {
+        target: root.paramsModel
+        function onAddressChanged(){
+            if (!root.changedProps.includes('address')){
+                root.address = root.paramsModel.address;
+            }
+        }
+    }
+
+    contentItem: GridLayout {
+        id: grid
+        property real cellWidth: 120
+        columns: 2
+        ValueLabel {
+            labelText: 'Address'
+            valueText: root.paramsModel ? root.paramsModel.address : ''
+            Layout.columnSpan: 2
+            Layout.alignment: Qt.AlignHCenter || Qt.AlignTop
+            Layout.preferredWidth: grid.cellWidth * 2
+        }
+        Indicator {
+            labelText: 'Syncronized'
+            valueState: root.paramsModel ? root.paramsModel.syncronized : false
+            Layout.alignment: Qt.AlignRight || Qt.AlignTop
+            Layout.preferredWidth: grid.cellWidth
+        }
+        Indicator {
+            labelText: 'TcSync'
+            valueState: root.paramsModel ? root.paramsModel.tcSync : false
+            Layout.alignment: Qt.AlignLeft || Qt.AlignTop
+            Layout.preferredWidth: grid.cellWidth
+        }
+        Indicator {
+            labelText: 'Sync Master'
+            valueState: root.paramsModel ? root.paramsModel.syncMaster : false
+            Layout.alignment: Qt.AlignRight || Qt.AlignTop
+            Layout.preferredWidth: grid.cellWidth
+        }
+        Item { Layout.preferredWidth: grid.cellWidth }
+        Item { Layout.columnSpan: 2; Layout.fillHeight: true }
+        TextInput {
+            labelText: 'Set Address'
+            valueText: root.address
+
+            Layout.columnSpan: 2
+            Layout.alignment: Qt.AlignHCenter || Qt.AlignTop
+            Layout.preferredWidth: grid.cellWidth * 2
+
+            onTextEdited: {
+                root.address = value;
+                root.hasChanges = true;
+                var props = root.changedProps.slice();
+                if (!props.includes('address')){
+                    props.push('address');
+                    root.changedProps = props;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add NTPParams
  - Retrieve current NTP server address and synchronization status
  - Add method to set NTP server address
- Add PresetZoom support
  - Retrieve the zoom position stored for presets `["A", "B", "C"]`
  - Track the camera's current zoom and indicate when it matches one or all of the presets
  - Add method to set preset zoom positions
- Add Seesaw operation for MasterBlack

Some of the UI changes required setting the `implicitWidth` on the main `contentItem` for the `Camera` component.  This should make the outer with of the component 390 (which was already the measured width).  Comments were added showing the expected widths of each level of content.